### PR TITLE
change nagios admin user back to 'nagiosadmin'

### DIFF
--- a/fh-mbaas-template-1node-persistent.json
+++ b/fh-mbaas-template-1node-persistent.json
@@ -1230,7 +1230,7 @@
     {
       "name": "NAGIOS_USER",
       "description": "Nagios admin username",
-      "value": "nagios-admin-user"
+      "value": "nagiosadmin"
     },
     {
       "name": "NAGIOS_PASSWORD",

--- a/fh-mbaas-template-3node.json
+++ b/fh-mbaas-template-3node.json
@@ -1699,7 +1699,7 @@
     {
       "name": "NAGIOS_USER",
       "description": "Nagios admin username",
-      "value": "nagios-admin-user"
+      "value": "nagiosadmin"
     },
     {
       "name": "NAGIOS_PASSWORD",


### PR DESCRIPTION
The nagiosadmin username appears to be hard-coded into the nagios container. So this value must remain as 'nagiosadmin' for now.