### PR TITLE
Clean up and tweak the templates

### DIFF
--- a/fh-mbaas-template-1node-persistent.json
+++ b/fh-mbaas-template-1node-persistent.json
@@ -39,6 +39,9 @@
         "name": "fh-mbaas-service",
         "labels": {
           "name": "fh-mbaas-service"
+        },
+        "annotations": {
+            "service.alpha.openshift.io/dependencies": "[{\"name\":\"mongodb-1\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-messaging-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-metrics-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-statsd-service\",\"namespace\":\"\",\"kind\":\"Service\"}]"
         }
       },
       "spec": {

--- a/fh-mbaas-template-1node-persistent.json
+++ b/fh-mbaas-template-1node-persistent.json
@@ -4,7 +4,7 @@
   "metadata": {
     "name": "fh-mbaas",
     "annotations": {
-      "templateVersion": "0.25.11",
+      "templateVersion": "0.26.0",
       "description": "Red Hat Mobile Backend as a Service template",
       "iconClass": "icon-nodejs"
     }
@@ -41,7 +41,7 @@
           "name": "fh-mbaas-service"
         },
         "annotations": {
-            "service.alpha.openshift.io/dependencies": "[{\"name\":\"mongodb-1\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-messaging-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-metrics-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-statsd-service\",\"namespace\":\"\",\"kind\":\"Service\"}]"
+          "service.alpha.openshift.io/dependencies": "[{\"name\":\"mongodb-1\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-messaging-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-metrics-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-statsd-service\",\"namespace\":\"\",\"kind\":\"Service\"}]"
         }
       },
       "spec": {

--- a/fh-mbaas-template-1node-persistent.json
+++ b/fh-mbaas-template-1node-persistent.json
@@ -143,6 +143,74 @@
       }
     },
     {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "nagios",
+        "labels": {
+          "name": "nagios"
+        },
+        "creationTimestamp": null
+      },
+      "spec": {
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 8080,
+            "targetPort": 8080
+          }
+        ],
+        "selector": {
+          "name": "nagios"
+        },
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "ServiceAccount",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "nagios"
+      }
+    },
+    {
+      "kind": "RoleBinding",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "nagiosadmin"
+      },
+      "subjects": [
+        {
+          "kind": "ServiceAccount",
+          "name": "nagios"
+        }
+      ],
+      "roleRef": {
+        "name": "admin"
+      }
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "nagios-claim-1"
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "1Gi"
+          }
+        }
+      }
+    },
+    {
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
@@ -669,8 +737,132 @@
       }
     },
     {
+      "kind": "DeploymentConfig",
       "apiVersion": "v1",
+      "metadata": {
+        "name": "nagios",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate",
+          "recreateParams": {
+            "timeoutSeconds": 600
+          },
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "name": "nagios"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "name": "nagios"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "nagios-data-volume",
+                "persistentVolumeClaim": {
+                  "claimName": "nagios-claim-1"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "nagios",
+                "image": "${NAGIOS_IMAGE}:${NAGIOS_IMAGE_VERSION}",
+                "ports": [
+                  {
+                    "containerPort": 8080,
+                    "protocol": "TCP"
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "nagios-data-volume",
+                    "mountPath": "/var/log/nagios"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "SMTP_SERVER",
+                    "value": "${SMTP_SERVER}"
+                  },
+                  {
+                    "name": "SMTP_USERNAME",
+                    "value": "${SMTP_USERNAME}"
+                  },
+                  {
+                    "name": "SMTP_PASSWORD",
+                    "value": "${SMTP_PASSWORD}"
+                  },
+                  {
+                    "name": "SMTP_TLS",
+                    "value": "${SMTP_TLS}"
+                  },
+                  {
+                    "name": "SMTP_FROM_ADDRESS",
+                    "value": "${SMTP_FROM_ADDRESS}"
+                  },
+                  {
+                    "name": "RHMAP_ADMIN_EMAIL",
+                    "value": "${RHMAP_ADMIN_EMAIL}"
+                  },
+                  {
+                    "name": "NAGIOS_USER",
+                    "value": "${NAGIOS_USER}"
+                  },
+                  {
+                    "name": "NAGIOS_PASSWORD",
+                    "value": "${NAGIOS_PASSWORD}"
+                  },
+                  {
+                    "name": "RHMAP_ROUTER_DNS",
+                    "value": "${RHMAP_ROUTER_DNS}"
+                  },
+                  {
+                    "name": "RHMAP_HOSTGROUPS",
+                    "value": "${RHMAP_HOSTGROUPS}"
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "cpu": "800m",
+                    "memory": "800Mi"
+                  },
+                  "requests": {
+                    "cpu": "200m",
+                    "memory": "200Mi"
+                  }
+                },
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "IfNotPresent"
+              }
+            ],
+            "restartPolicy": "Always",
+            "terminationGracePeriodSeconds": 30,
+            "dnsPolicy": "ClusterFirst",
+            "serviceAccountName": "nagios",
+            "serviceAccount": "nagios",
+            "securityContext": {}
+          }
+        }
+      },
+      "status": {}
+    },
+    {
       "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
       "metadata": {
         "name": "mongodb-claim-1"
       },
@@ -838,198 +1030,6 @@
           "insecureEdgeTerminationPolicy": "Allow"
         }
       }
-    },
-    {
-      "kind": "Service",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "nagios",
-        "labels": {
-          "name": "nagios"
-        },
-        "creationTimestamp": null
-      },
-      "spec": {
-        "ports": [
-          {
-            "protocol": "TCP",
-            "port": 8080,
-            "targetPort": 8080
-          }
-        ],
-        "selector": {
-          "name": "nagios"
-        },
-        "type": "ClusterIP",
-        "sessionAffinity": "None"
-      },
-      "status": {
-        "loadBalancer": {}
-      }
-    },
-    {
-      "kind": "ServiceAccount",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "nagios"
-      }
-    },
-    {
-      "kind": "RoleBinding",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "nagiosadmin"
-      },
-      "subjects": [
-        {
-          "kind": "ServiceAccount",
-          "name": "nagios"
-        }
-      ],
-      "roleRef": {
-        "name": "admin"
-      }
-    },
-    {
-      "kind": "PersistentVolumeClaim",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "nagios-claim-1"
-      },
-      "spec": {
-        "accessModes": [
-          "ReadWriteOnce"
-        ],
-        "resources": {
-          "requests": {
-            "storage": "1Gi"
-          }
-        }
-      }
-    },
-    {
-      "kind": "DeploymentConfig",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "nagios",
-        "creationTimestamp": null
-      },
-      "spec": {
-        "strategy": {
-          "type": "Recreate",
-          "recreateParams": {
-            "timeoutSeconds": 600
-          },
-          "resources": {}
-        },
-        "triggers": [
-          {
-            "type": "ConfigChange"
-          }
-        ],
-        "replicas": 1,
-        "test": false,
-        "selector": {
-          "name": "nagios"
-        },
-        "template": {
-          "metadata": {
-            "creationTimestamp": null,
-            "labels": {
-              "name": "nagios"
-            }
-          },
-          "spec": {
-            "volumes": [
-              {
-                "name": "nagios-data-volume",
-                "persistentVolumeClaim": {
-                  "claimName": "nagios-claim-1"
-                }
-              }
-            ],
-            "containers": [
-              {
-                "name": "nagios",
-                "image": "${NAGIOS_IMAGE}:${NAGIOS_IMAGE_VERSION}",
-                "ports": [
-                  {
-                    "containerPort": 8080,
-                    "protocol": "TCP"
-                  }
-                ],
-                "volumeMounts": [
-                  {
-                    "name": "nagios-data-volume",
-                    "mountPath": "/var/log/nagios"
-                  }
-                ],
-                "env": [
-                  {
-                    "name": "SMTP_SERVER",
-                    "value": "${SMTP_SERVER}"
-                  },
-                  {
-                    "name": "SMTP_USERNAME",
-                    "value": "${SMTP_USERNAME}"
-                  },
-                  {
-                    "name": "SMTP_PASSWORD",
-                    "value": "${SMTP_PASSWORD}"
-                  },
-                  {
-                    "name": "SMTP_TLS",
-                    "value": "${SMTP_TLS}"
-                  },
-                  {
-                    "name": "SMTP_FROM_ADDRESS",
-                    "value": "${SMTP_FROM_ADDRESS}"
-                  },
-                  {
-                    "name": "RHMAP_ADMIN_EMAIL",
-                    "value": "${RHMAP_ADMIN_EMAIL}"
-                  },
-                  {
-                    "name": "NAGIOS_USER",
-                    "value": "${NAGIOS_USER}"
-                  },
-                  {
-                    "name": "NAGIOS_PASSWORD",
-                    "value": "${NAGIOS_PASSWORD}"
-                  },
-                  {
-                    "name": "RHMAP_ROUTER_DNS",
-                    "value": "${RHMAP_ROUTER_DNS}"
-                  },
-                  {
-                    "name": "RHMAP_HOSTGROUPS",
-                    "value": "${RHMAP_HOSTGROUPS}"
-                  }
-                ],
-                "resources": {
-                  "limits": {
-                    "cpu": "800m",
-                    "memory": "800Mi"
-                  },
-                  "requests": {
-                    "cpu": "200m",
-                    "memory": "200Mi"
-                  }
-                },
-                "terminationMessagePath": "/dev/termination-log",
-                "imagePullPolicy": "IfNotPresent"
-              }
-            ],
-            "restartPolicy": "Always",
-            "terminationGracePeriodSeconds": 30,
-            "dnsPolicy": "ClusterFirst",
-            "serviceAccountName": "nagios",
-            "serviceAccount": "nagios",
-            "securityContext": {}
-          }
-        }
-      },
-      "status": {}
     },
     {
       "kind": "Route",

--- a/fh-mbaas-template-1node-persistent.json
+++ b/fh-mbaas-template-1node-persistent.json
@@ -238,7 +238,7 @@
             "type": "ConfigChange"
           }
         ],
-        "replicas": 1,
+        "replicas": "${FH_MBAAS_REPLICAS}",
         "selector": {
           "name": "fh-mbaas"
         },
@@ -399,7 +399,7 @@
             "type": "ConfigChange"
           }
         ],
-        "replicas": 1,
+        "replicas": "${FH_MESSAGING_REPLICAS}",
         "selector": {
           "name": "fh-messaging"
         },
@@ -526,7 +526,7 @@
             "type": "ConfigChange"
           }
         ],
-        "replicas": 1,
+        "replicas": "${FH_METRICS_REPLICAS}",
         "selector": {
           "name": "fh-metrics"
         },
@@ -1180,22 +1180,22 @@
     },
     {
       "name": "ENDPOINT_COUNT",
-      "description": "The amount of database's to create a replica set",
+      "description": "The number of databases to create in a replica set",
       "value": "1"
     },
     {
       "name": "FH_MBAAS_REPLICAS",
-      "description": "Replica used for sizing",
+      "description": "Number of fh-mbaas replicas to create",
       "value": "1"
     },
     {
       "name": "FH_MESSAGING_REPLICAS",
-      "description": "Replica used for sizing",
+      "description": "Number of fh-messaging replicas to create",
       "value": "1"
     },
     {
       "name": "FH_METRICS_REPLICAS",
-      "description": "Replica used for sizing",
+      "description": "Number of fh-metrics replicas to create",
       "value": "1"
     },
     {

--- a/fh-mbaas-template-1node-persistent.json
+++ b/fh-mbaas-template-1node-persistent.json
@@ -11,23 +11,6 @@
   },
   "objects": [
     {
-      "apiVersion": "v1",
-      "kind": "PersistentVolumeClaim",
-      "metadata": {
-        "name": "mongodb-claim-1"
-      },
-      "spec": {
-        "accessModes": [
-          "ReadWriteOnce"
-        ],
-        "resources": {
-          "requests": {
-            "storage": "${MONGODB_PVC_SIZE}"
-          }
-        }
-      }
-    },
-    {
       "kind": "ConfigMap",
       "apiVersion": "v1",
       "metadata": {
@@ -681,6 +664,23 @@
                 }
               }
             ]
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "PersistentVolumeClaim",
+      "metadata": {
+        "name": "mongodb-claim-1"
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "${MONGODB_PVC_SIZE}"
           }
         }
       }

--- a/fh-mbaas-template-1node-persistent.json
+++ b/fh-mbaas-template-1node-persistent.json
@@ -672,6 +672,14 @@
                 },
                 "imagePullPolicy": "IfNotPresent"
               }
+            ],
+            "volumes": [
+              {
+                "name": "node-proxy",
+                "configMap": {
+                  "name": "node-proxy"
+                }
+              }
             ]
           }
         }

--- a/fh-mbaas-template-1node-persistent.json
+++ b/fh-mbaas-template-1node-persistent.json
@@ -154,7 +154,7 @@
           }
         ],
         "selector": {
-          "name": "mongodb-replica"
+          "name": "mongodb-replica-1"
         },
         "clusterIP": "None"
       }
@@ -715,12 +715,12 @@
         ],
         "replicas": 1,
         "selector": {
-          "name": "mongodb-replica"
+          "name": "mongodb-replica-1"
         },
         "template": {
           "metadata": {
             "labels": {
-              "name": "mongodb-replica"
+              "name": "mongodb-replica-1"
             }
           },
           "spec": {
@@ -734,11 +734,17 @@
             ],
             "containers": [
               {
-                "name": "mongodb-1",
+                "name": "mongodb-service",
                 "image": "${MONGODB_IMAGE}:${MONGODB_IMAGE_VERSION}",
                 "ports": [
                   {
                     "containerPort": 27017
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "mongodb-data-volume",
+                    "mountPath": "/var/lib/mongodb/data"
                   }
                 ],
                 "env": [
@@ -805,12 +811,6 @@
                     "memory": "200Mi"
                   }
                 },
-                "volumeMounts": [
-                  {
-                    "name": "mongodb-data-volume",
-                    "mountPath": "/var/lib/mongodb/data"
-                  }
-                ],
                 "imagePullPolicy": "IfNotPresent"
               }
             ]

--- a/fh-mbaas-template-1node.json
+++ b/fh-mbaas-template-1node.json
@@ -137,7 +137,7 @@
           }
         ],
         "selector": {
-          "name": "mongodb-replica"
+          "name": "mongodb-replica-1"
         },
         "clusterIP": "None"
       }
@@ -689,9 +689,6 @@
               "cpu": "200m",
               "memory": "200Mi"
             }
-          },
-          "recreateParams": {
-            "timeoutSeconds": 600
           }
         },
         "triggers": [
@@ -700,31 +697,29 @@
           }
         ],
         "replicas": 1,
-        "test": false,
         "selector": {
-          "name": "mongodb-replica"
+          "name": "mongodb-replica-1"
         },
         "template": {
           "metadata": {
             "labels": {
-              "name": "mongodb-replica"
+              "name": "mongodb-replica-1"
             }
           },
           "spec": {
             "containers": [
               {
-                "name": "mongodb-1",
+                "name": "mongodb-service",
                 "image": "${MONGODB_IMAGE}:${MONGODB_IMAGE_VERSION}",
                 "ports": [
                   {
-                    "containerPort": 27017,
-                    "protocol": "TCP"
+                    "containerPort": 27017
                   }
                 ],
                 "env": [
                   {
                     "name": "MONGODB_SERVICE_NAME",
-                    "value": "${MONGODB_SERVICE_NAME}"
+                    "value": "mongodb"
                   },
                   {
                     "name": "MONGODB_KEYFILE_VALUE",

--- a/fh-mbaas-template-1node.json
+++ b/fh-mbaas-template-1node.json
@@ -39,6 +39,9 @@
         "name": "fh-mbaas-service",
         "labels": {
           "name": "fh-mbaas-service"
+        },
+        "annotations": {
+            "service.alpha.openshift.io/dependencies": "[{\"name\":\"mongodb-1\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-messaging-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-metrics-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-statsd-service\",\"namespace\":\"\",\"kind\":\"Service\"}]"
         }
       },
       "spec": {

--- a/fh-mbaas-template-1node.json
+++ b/fh-mbaas-template-1node.json
@@ -937,6 +937,26 @@
       "value": ""
     },
     {
+      "name": "ENDPOINT_COUNT",
+      "description": "The number of databases to create in a replica set",
+      "value": "1"
+    },
+    {
+      "name": "FH_MBAAS_REPLICAS",
+      "description": "Number of fh-mbaas replicas to create",
+      "value": "1"
+    },
+    {
+      "name": "FH_MESSAGING_REPLICAS",
+      "description": "Number of fh-messaging replicas to create",
+      "value": "1"
+    },
+    {
+      "name": "FH_METRICS_REPLICAS",
+      "description": "Number of fh-metrics replicas to create",
+      "value": "1"
+    },
+    {
       "name": "FH_STATSD_API_KEY",
       "description": "Key for communicating with the FH_STATSD Service",
       "generate": "expression",

--- a/fh-mbaas-template-1node.json
+++ b/fh-mbaas-template-1node.json
@@ -4,7 +4,7 @@
   "metadata": {
     "name": "fh-mbaas",
     "annotations": {
-      "templateVersion": "0.25.11",
+      "templateVersion": "0.26.0",
       "description": "Red Hat Mobile Backend as a Service template",
       "iconClass": "icon-nodejs"
     }
@@ -41,7 +41,7 @@
           "name": "fh-mbaas-service"
         },
         "annotations": {
-            "service.alpha.openshift.io/dependencies": "[{\"name\":\"mongodb-1\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-messaging-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-metrics-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-statsd-service\",\"namespace\":\"\",\"kind\":\"Service\"}]"
+          "service.alpha.openshift.io/dependencies": "[{\"name\":\"mongodb-1\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-messaging-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-metrics-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-statsd-service\",\"namespace\":\"\",\"kind\":\"Service\"}]"
         }
       },
       "spec": {

--- a/fh-mbaas-template-1node.json
+++ b/fh-mbaas-template-1node.json
@@ -170,7 +170,7 @@
             "type": "ConfigChange"
           }
         ],
-        "replicas": 1,
+        "replicas": "${FH_MBAAS_REPLICAS}",
         "selector": {
           "name": "fh-mbaas"
         },
@@ -331,7 +331,7 @@
             "type": "ConfigChange"
           }
         ],
-        "replicas": 1,
+        "replicas": "${FH_MESSAGING_REPLICAS}",
         "selector": {
           "name": "fh-messaging"
         },
@@ -458,7 +458,7 @@
             "type": "ConfigChange"
           }
         ],
-        "replicas": 1,
+        "replicas": "${FH_METRICS_REPLICAS}",
         "selector": {
           "name": "fh-metrics"
         },
@@ -782,15 +782,10 @@
                 },
                 "imagePullPolicy": "IfNotPresent"
               }
-            ],
-            "restartPolicy": "Always",
-            "terminationGracePeriodSeconds": 30,
-            "dnsPolicy": "ClusterFirst",
-            "securityContext": {}
+            ]
           }
         }
-      },
-      "status": {}
+      }
     },
     {
       "kind": "Route",

--- a/fh-mbaas-template-3node.json
+++ b/fh-mbaas-template-3node.json
@@ -39,6 +39,9 @@
         "name": "fh-mbaas-service",
         "labels": {
           "name": "fh-mbaas-service"
+        },
+        "annotations": {
+            "service.alpha.openshift.io/dependencies": "[{\"name\":\"mongodb-1\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-messaging-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-metrics-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-statsd-service\",\"namespace\":\"\",\"kind\":\"Service\"}]"
         }
       },
       "spec": {

--- a/fh-mbaas-template-3node.json
+++ b/fh-mbaas-template-3node.json
@@ -4,7 +4,7 @@
   "metadata": {
     "name": "fh-mbaas",
     "annotations": {
-      "templateVersion": "0.25.11",
+      "templateVersion": "0.26.0",
       "description": "Red Hat Mobile Backend as a Service template",
       "iconClass": "icon-nodejs"
     }
@@ -41,7 +41,7 @@
           "name": "fh-mbaas-service"
         },
         "annotations": {
-            "service.alpha.openshift.io/dependencies": "[{\"name\":\"mongodb-1\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-messaging-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-metrics-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-statsd-service\",\"namespace\":\"\",\"kind\":\"Service\"}]"
+          "service.alpha.openshift.io/dependencies": "[{\"name\":\"mongodb-1\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-messaging-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-metrics-service\",\"namespace\":\"\",\"kind\":\"Service\"},{\"name\":\"fh-statsd-service\",\"namespace\":\"\",\"kind\":\"Service\"}]"
         }
       },
       "spec": {

--- a/fh-mbaas-template-3node.json
+++ b/fh-mbaas-template-3node.json
@@ -280,7 +280,7 @@
             "type": "ConfigChange"
           }
         ],
-        "replicas": 3,
+        "replicas": "${FH_MBAAS_REPLICAS}",
         "selector": {
           "name": "fh-mbaas"
         },
@@ -445,7 +445,7 @@
             "type": "ConfigChange"
           }
         ],
-        "replicas": 3,
+        "replicas": "${FH_MESSAGING_REPLICAS}",
         "selector": {
           "name": "fh-messaging"
         },
@@ -576,7 +576,7 @@
             "type": "ConfigChange"
           }
         ],
-        "replicas": 3,
+        "replicas": "${FH_METRICS_REPLICAS}",
         "selector": {
           "name": "fh-metrics"
         },
@@ -1647,22 +1647,22 @@
     },
     {
       "name": "ENDPOINT_COUNT",
-      "description": "The amount of database's to create a replica set",
+      "description": "The number of databases to create in a replica set",
       "value": "3"
     },
     {
       "name": "FH_MBAAS_REPLICAS",
-      "description": "Replica used for sizing",
+      "description": "Number of fh-mbaas replicas to create",
       "value": "3"
     },
     {
       "name": "FH_MESSAGING_REPLICAS",
-      "description": "Replica used for sizing",
+      "description": "Number of fh-messaging replicas to create",
       "value": "3"
     },
     {
       "name": "FH_METRICS_REPLICAS",
-      "description": "Replica used for sizing",
+      "description": "Number of fh-metrics replicas to create",
       "value": "3"
     },
     {

--- a/fh-mbaas-template-3node.json
+++ b/fh-mbaas-template-3node.json
@@ -926,7 +926,7 @@
         ],
         "resources": {
           "requests": {
-            "storage": "50Gi"
+            "storage": "${MONGODB_PVC_SIZE}"
           }
         }
       }
@@ -943,7 +943,7 @@
         ],
         "resources": {
           "requests": {
-            "storage": "50Gi"
+            "storage": "${MONGODB_PVC_SIZE}"
           }
         }
       }
@@ -960,7 +960,7 @@
         ],
         "resources": {
           "requests": {
-            "storage": "50Gi"
+            "storage": "${MONGODB_PVC_SIZE}"
           }
         }
       }
@@ -1675,6 +1675,12 @@
       "name": "FH_DEFAULT_LOG_LEVEL",
       "description": "A default log level for all MBaaS components",
       "value": "info"
+    },
+    {
+      "name": "MONGODB_PVC_SIZE",
+      "description": "The size of the volume for MongoDB Data",
+      "value": "50Gi",
+      "required": true
     },
     {
       "name": "SMTP_SERVER",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fh-openshift-templates",
   "description": "OpenShift V3 Templates for FH MBaaS",
-  "version": "0.25.11",
+  "version": "0.26.0",
   "scripts": {
     "get-images": "node ./scripts/get-images.js",
     "update-param": "node ./scripts/update-param.js",


### PR DESCRIPTION
The main purpose of this changeset was to make the templates more diff-able. I've made a couple of other changes while I was here:

* Allow fh-mbaas/fh-messaging/fh-metrics replica count to be customized at creation from template (parameters already existed, but weren't being used).
* Allow specifying the size of the PVC for MongoDB in the 3 node template, to match how it's done in the persistent single node template
* Group the MBaaS components in the OpenShift web console
* Add a missing configmap mount to fh-statsd from the recent HTTP proxy work

Here's what the new grouping looks like in the OpenShift web console:

![screenshot from 2017-02-07 15-24-12](https://cloud.githubusercontent.com/assets/442386/22697511/88bd4cda-ed49-11e6-800d-e0f162bc5d49.png)
