### PR TITLE
bumping MBaaS template version

### DIFF
--- a/rhmap-mbaas-config.json
+++ b/rhmap-mbaas-config.json
@@ -35,7 +35,7 @@
         "name": "fh-mbaas-info"
       },
       "data": {
-        "version": "4.5.0"
+        "version": "4.5.4"
       }
     },
     {


### PR DESCRIPTION
## Why?
bumping version number on MBaaS template as part of https://issues.jboss.org/browse/RHMAP-19121 as requested on https://github.com/fheng/fh-core-openshift-templates/pull/1192

## What?
changing version from 4.5.0 to 4.5.4
- [x] version changed