### PR TITLE
mongo configmap name

### DIFF
--- a/fh-mbaas-components.json
+++ b/fh-mbaas-components.json
@@ -294,6 +294,80 @@
                     }
                   },
                   {
+                    "name": "MONGODB_SERVICE_NAME",
+                    "valueFrom": {
+                      "configMapKeyRef": {
+                        "name": "mongo-config",
+                        "key": "mongodb-service-name"
+                      }
+                    }
+                  },
+
+                  {
+                    "name": "MONGODB_USERDB_REPLICA_NAME",
+                    "valueFrom": {
+                      "configMapKeyRef": {
+                        "name": "mongo-user-config",
+                        "key": "mongodb-replica-name"
+                      }
+                    }
+                  },
+                  {
+                    "name": "MONGODB_USERDB_FHMBAAS_USER",
+                    "valueFrom": {
+                      "configMapKeyRef": {
+                        "name": "mongo-user-config",
+                        "key": "mongodb-fhmbaas-user"
+                      }
+                    }
+                  },
+                  {
+                    "name": "MONGODB_USERDB_FHMBAAS_PASSWORD",
+                    "valueFrom": {
+                      "configMapKeyRef": {
+                        "name": "mongo-user-config",
+                        "key": "mongodb-fhmbaas-password"
+                      }
+                    }
+                  },
+                  {
+                    "name": "MONGODB_USERDB_FHMBAAS_DATABASE",
+                    "valueFrom": {
+                      "configMapKeyRef": {
+                        "name": "mongo-user-config",
+                        "key": "mongodb-fhmbaas-database"
+                      }
+                    }
+                  },
+                  {
+                    "name": "MONGODB_USERDB_ADMIN_PASSWORD",
+                    "valueFrom": {
+                      "configMapKeyRef": {
+                        "name": "mongo-user-config",
+                        "key": "mongodb-admin-password"
+                      }
+                    }
+                  },
+                  {
+                    "name": "MONGODB_USERDB_FORM_PASSWORD",
+                    "valueFrom": {
+                      "configMapKeyRef": {
+                        "name": "mongo-user-config",
+                        "key": "mongodb-form-password"
+                      }
+                    }
+                  },
+                  {
+                    "name": "MONGODB_USERDB_SERVICE_NAME",
+                    "valueFrom": {
+                      "configMapKeyRef": {
+                        "name": "mongo-user-config",
+                        "key": "mongodb-service-name"
+                      }
+                    }
+                  },
+
+                  {
                     "name": "FH_METRICS_API_KEY",
                     "description": "API Key for calling fh-metrics",
                     "value": "${FH_METRICS_API_KEY}"

--- a/rhmap-mbaas-config.json
+++ b/rhmap-mbaas-config.json
@@ -12,7 +12,7 @@
       "kind": "ConfigMap",
       "apiVersion": "v1",
       "metadata": {
-        "name": "mongo-config"
+        "name": "${MONGODB_CONFIGMAP_NAME}"
       },
       "data": {
          "mongodb-admin-password": "${MONGODB_ADMIN_PASSWORD}",
@@ -125,6 +125,12 @@
       "name": "PROJECT_NAME",
       "displayName": "RHMAP MBaaS project namespace",
       "value": "",
+      "required": true
+    },
+    {
+      "name": "MONGODB_CONFIGMAP_NAME",
+      "displayName": "Config map name",
+      "value": "mongo-config",
       "required": true
     }
   ]


### PR DESCRIPTION
adds `MONGODB_CONFIGMAP_NAME` template param (defaults to `mongo-config`)

@PhilipGough  do you think it makes sense to apply this change to all templates?