### PR TITLE
added mongodb service envar

### DIFF
--- a/fh-mbaas-components.json
+++ b/fh-mbaas-components.json
@@ -549,6 +549,15 @@
                       }
                     }
                   },
+                   {
+                    "name": "MONGODB_SERVICE_NAME",
+                    "valueFrom": {
+                      "configMapKeyRef": {
+                        "name": "mongo-config",
+                        "key": "mongodb-service-name"
+                      }
+                    }
+                  },
                   {
                     "name": "FH_MESSAGING_API_KEY",
                     "description": "API Key for calling fh-messaging",
@@ -720,6 +729,15 @@
                       "configMapKeyRef": {
                         "name": "mongo-config",
                         "key": "mongodb-fhreporting-database"
+                      }
+                    }
+                  },
+                   {
+                    "name": "MONGODB_SERVICE_NAME",
+                    "valueFrom": {
+                      "configMapKeyRef": {
+                        "name": "mongo-config",
+                        "key": "mongodb-service-name"
                       }
                     }
                   },


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/RHMAP-19792

Changes:
Added envar to messaging and metrics deployment configs to use the mongodb _service_name value from the configmap which will ensure the components dont fail when mongodb-1 is not available

Verfification: 

Deploy 3 node mbaas
ensure the envar exists for each component
Scale down the mongodb1 pod
Scale down messaging and metrics to 1 and scale back up to 3 - they should both go blue and connect successfully
