### PR TITLE
add tunable request/limit params

### DIFF
--- a/fh-mbaas-components.json
+++ b/fh-mbaas-components.json
@@ -181,17 +181,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Rolling",
-          "resources": {
-            "limits": {
-              "cpu": "800m",
-              "memory": "800Mi"
-            },
-            "requests": {
-              "cpu": "200m",
-              "memory": "200Mi"
-            }
-          }
+          "type": "Rolling"
         },
         "triggers": [
           {
@@ -351,12 +341,12 @@
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "800m",
-                    "memory": "800Mi"
+                    "cpu": "${FH_MBAAS_CPU_LIMIT}",
+                    "memory": "${FH_MBAAS_MEMORY_LIMIT}"
                   },
                   "requests": {
-                    "cpu": "200m",
-                    "memory": "200Mi"
+                    "cpu": "${FH_MBAAS_CPU_REQUEST}",
+                    "memory": "${FH_MBAAS_MEMORY_REQUEST}"
                   }
                 },
                 "livenessProbe": {
@@ -408,17 +398,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Rolling",
-          "resources": {
-            "limits": {
-              "cpu": "400m",
-              "memory": "400Mi"
-            },
-            "requests": {
-              "cpu": "200m",
-              "memory": "200Mi"
-            }
-          }
+          "type": "Rolling"
         },
         "triggers": [
           {
@@ -534,12 +514,12 @@
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "400m",
-                    "memory": "400Mi"
+                    "cpu": "${FH_MESSAGING_CPU_LIMIT}",
+                    "memory": "${FH_MESSAGING_MEMORY_LIMIT}"
                   },
                   "requests": {
-                    "cpu": "200m",
-                    "memory": "200Mi"
+                    "cpu": "${FH_MESSAGING_CPU_REQUEST}",
+                    "memory": "${FH_MESSAGING_MEMORY_REQUEST}"
                   }
                 },
                 "livenessProbe": {
@@ -591,17 +571,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Rolling",
-          "resources": {
-            "limits": {
-              "cpu": "400m",
-              "memory": "400Mi"
-            },
-            "requests": {
-              "cpu": "200m",
-              "memory": "200Mi"
-            }
-          }
+          "type": "Rolling"
         },
         "triggers": [
           {
@@ -717,12 +687,12 @@
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "400m",
-                    "memory": "400Mi"
+                    "cpu": "${FH_METRICS_CPU_LIMIT}",
+                    "memory": "${FH_METRICS_MEMORY_LIMIT}"
                   },
                   "requests": {
-                    "cpu": "200m",
-                    "memory": "200Mi"
+                    "cpu": "${FH_METRICS_CPU_REQUEST}",
+                    "memory": "${FH_METRICS_MEMORY_REQUEST}"
                   }
                 },
                 "livenessProbe": {
@@ -774,17 +744,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Rolling",
-          "resources": {
-            "limits": {
-              "cpu": "400m",
-              "memory": "400Mi"
-            },
-            "requests": {
-              "cpu": "200m",
-              "memory": "200Mi"
-            }
-          }
+          "type": "Rolling"
         },
         "triggers": [
           {
@@ -851,12 +811,12 @@
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "400m",
-                    "memory": "400Mi"
+                    "cpu": "${FH_STATSD_CPU_LIMIT}",
+                    "memory": "${FH_STATSD_MEMORY_LIMIT}"
                   },
                   "requests": {
-                    "cpu": "200m",
-                    "memory": "200Mi"
+                    "cpu": "${FH_STATSD_CPU_REQUEST}",
+                    "memory": "${FH_STATSD_MEMORY_REQUEST}"
                   }
                 },
                 "livenessProbe": {
@@ -909,8 +869,7 @@
           "type": "Recreate",
           "recreateParams": {
             "timeoutSeconds": 600
-          },
-          "resources": {}
+          }
         },
         "triggers": [
           {
@@ -1002,12 +961,12 @@
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "800m",
-                    "memory": "800Mi"
+                    "cpu": "${NAGIOS_CPU_LIMIT}",
+                    "memory": "${NAGIOS_MEMORY_LIMIT}"
                   },
                   "requests": {
-                    "cpu": "200m",
-                    "memory": "200Mi"
+                    "cpu": "${NAGIOS_CPU_REQUEST}",
+                    "memory": "${NAGIOS_MEMORY_REQUEST}"
                   }
                 },
                 "terminationMessagePath": "/dev/termination-log",
@@ -1117,6 +1076,34 @@
       "description": "The version for the FH_MBAAS_IMAGE"
     },
     {
+      "name": "FH_MBAAS_CPU_REQUEST",
+      "displayName": "CPU Request",
+      "description": "Minimum amount of CPU the container can use.",
+      "value": "1m",
+      "required": true
+    },
+    {
+      "name": "FH_MBAAS_CPU_LIMIT",
+      "displayName": "CPU Limit",
+      "description": "Maximum amount of CPU the container can use.",
+      "value": "200m",
+      "required": true
+    },
+    {
+      "name": "FH_MBAAS_MEMORY_REQUEST",
+      "displayName": "Memory Request",
+      "description": "Minimum amount of memory the container can use.",
+      "value": "130Mi",
+      "required": true
+    },
+    {
+      "name": "FH_MBAAS_MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "description": "Maximum amount of memory the container can use.",
+      "value": "250Mi",
+      "required": true
+    },
+    {
       "name": "FH_MESSAGING_IMAGE",
       "value": "docker.io/feedhenry/fh-messaging",
       "description": "The name of the fh-messaging image"
@@ -1125,6 +1112,34 @@
       "name": "FH_MESSAGING_IMAGE_VERSION",
       "value": "3.3.12BUILD-9ccafb3",
       "description": "The version for the FH_MESSAGING_IMAGE"
+    },
+    {
+      "name": "FH_MESSAGING_CPU_REQUEST",
+      "displayName": "CPU Request",
+      "description": "Minimum amount of CPU the container can use.",
+      "value": "1m",
+      "required": true
+    },
+    {
+      "name": "FH_MESSAGING_CPU_LIMIT",
+      "displayName": "CPU Limit",
+      "description": "Maximum amount of CPU the container can use.",
+      "value": "200m",
+      "required": true
+    },
+    {
+      "name": "FH_MESSAGING_MEMORY_REQUEST",
+      "displayName": "Memory Request",
+      "description": "Minimum amount of memory the container can use.",
+      "value": "50Mi",
+      "required": true
+    },
+    {
+      "name": "FH_MESSAGING_MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "description": "Maximum amount of memory the container can use.",
+      "value": "100Mi",
+      "required": true
     },
     {
       "name": "FH_METRICS_IMAGE",
@@ -1137,6 +1152,34 @@
       "description": "The version for the FH_METRICS_IMAGE"
     },
     {
+      "name": "FH_METRICS_CPU_REQUEST",
+      "displayName": "CPU Request",
+      "description": "Minimum amount of CPU the container can use.",
+      "value": "1m",
+      "required": true
+    },
+    {
+      "name": "FH_METRICS_CPU_LIMIT",
+      "displayName": "CPU Limit",
+      "description": "Maximum amount of CPU the container can use.",
+      "value": "200m",
+      "required": true
+    },
+    {
+      "name": "FH_METRICS_MEMORY_REQUEST",
+      "displayName": "Memory Request",
+      "description": "Minimum amount of memory the container can use.",
+      "value": "40Mi",
+      "required": true
+    },
+    {
+      "name": "FH_METRICS_MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "description": "Maximum amount of memory the container can use.",
+      "value": "100Mi",
+      "required": true
+    },
+    {
       "name": "FH_STATSD_IMAGE",
       "value": "docker.io/feedhenry/fh-statsd",
       "description": "The name of the fh-statsd image"
@@ -1145,6 +1188,34 @@
       "name": "FH_STATSD_IMAGE_VERSION",
       "value": "2.1.3-7f508f2",
       "description": "The version for the FH_STATSD_IMAGE"
+    },
+    {
+      "name": "FH_STATSD_CPU_REQUEST",
+      "displayName": "CPU Request",
+      "description": "Minimum amount of CPU the container can use.",
+      "value": "1m",
+      "required": true
+    },
+    {
+      "name": "FH_STATSD_CPU_LIMIT",
+      "displayName": "CPU Limit",
+      "description": "Maximum amount of CPU the container can use.",
+      "value": "200m",
+      "required": true
+    },
+    {
+      "name": "FH_STATSD_MEMORY_REQUEST",
+      "displayName": "Memory Request",
+      "description": "Minimum amount of memory the container can use.",
+      "value": "25Mi",
+      "required": true
+    },
+    {
+      "name": "FH_STATSD_MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "description": "Maximum amount of memory the container can use.",
+      "value": "50Mi",
+      "required": true
     },
     {
       "name": "FH_MESSAGING_API_KEY",
@@ -1254,6 +1325,34 @@
       "name": "NAGIOS_IMAGE_VERSION",
       "description": "The version of the Nagios Docker image",
       "value": "4.0.8-4d0a0ae"
+    },
+    {
+      "name": "NAGIOS_CPU_REQUEST",
+      "displayName": "CPU Request",
+      "description": "Minimum amount of CPU the container can use.",
+      "value": "1m",
+      "required": true
+    },
+    {
+      "name": "NAGIOS_CPU_LIMIT",
+      "displayName": "CPU Limit",
+      "description": "Maximum amount of CPU the container can use.",
+      "value": "1",
+      "required": true
+    },
+    {
+      "name": "NAGIOS_MEMORY_REQUEST",
+      "displayName": "Memory Request",
+      "description": "Minimum amount of memory the container can use.",
+      "value": "35Mi",
+      "required": true
+    },
+    {
+      "name": "NAGIOS_MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "description": "Maximum amount of memory the container can use.",
+      "value": "150Mi",
+      "required": true
     }
   ]
 }

--- a/mongo-replica-affinity.json
+++ b/mongo-replica-affinity.json
@@ -58,17 +58,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {
-            "limits": {
-              "cpu": "1000m",
-              "memory": "1000Mi"
-            },
-            "requests": {
-              "cpu": "200m",
-              "memory": "200Mi"
-            }
-          }
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -226,12 +216,12 @@
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "1000m",
-                    "memory": "1000Mi"
+                    "cpu": "${MONGODB_CPU_LIMIT}",
+                    "memory": "${MONGODB_MEMORY_LIMIT}"
                   },
                   "requests": {
-                    "cpu": "200m",
-                    "memory": "200Mi"
+                    "cpu": "${MONGODB_CPU_REQUEST}",
+                    "memory": "${MONGODB_MEMORY_REQUEST}"
                   }
                 },
                 "livenessProbe": {
@@ -290,6 +280,34 @@
       "description": "The key to use for anti-affinity rule in deployment",
       "required": true,
       "value": "mongodb-3-node-replica-set"
+    },
+    {
+      "name": "MONGODB_CPU_REQUEST",
+      "displayName": "CPU Request",
+      "description": "Minimum amount of CPU the container can use.",
+      "value": "5m",
+      "required": true
+    },
+    {
+      "name": "MONGODB_CPU_LIMIT",
+      "displayName": "CPU Limit",
+      "description": "Maximum amount of CPU the container can use.",
+      "value": "1",
+      "required": true
+    },
+    {
+      "name": "MONGODB_MEMORY_REQUEST",
+      "displayName": "Memory Request",
+      "description": "Minimum amount of memory the container can use.",
+      "value": "200Mi",
+      "required": true
+    },
+    {
+      "name": "MONGODB_MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "description": "Maximum amount of memory the container can use.",
+      "value": "1000Mi",
+      "required": true
     }
   ]
 }

--- a/mongo-replica.json
+++ b/mongo-replica.json
@@ -58,17 +58,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {
-            "limits": {
-              "cpu": "1000m",
-              "memory": "1000Mi"
-            },
-            "requests": {
-              "cpu": "200m",
-              "memory": "200Mi"
-            }
-          }
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -209,12 +199,12 @@
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "1000m",
-                    "memory": "1000Mi"
+                    "cpu": "${MONGODB_CPU_LIMIT}",
+                    "memory": "${MONGODB_MEMORY_LIMIT}"
                   },
                   "requests": {
-                    "cpu": "200m",
-                    "memory": "200Mi"
+                    "cpu": "${MONGODB_CPU_REQUEST}",
+                    "memory": "${MONGODB_MEMORY_REQUEST}"
                   }
                 },
                 "livenessProbe": {
@@ -270,6 +260,34 @@
     {
       "name": "NODE_SELECTOR_VALUE",
       "description": "The node label value to schedule this Mongo instance",
+      "required": true
+    },
+    {
+      "name": "MONGODB_CPU_REQUEST",
+      "displayName": "CPU Request",
+      "description": "Minimum amount of CPU the container can use.",
+      "value": "5m",
+      "required": true
+    },
+    {
+      "name": "MONGODB_CPU_LIMIT",
+      "displayName": "CPU Limit",
+      "description": "Maximum amount of CPU the container can use.",
+      "value": "1",
+      "required": true
+    },
+    {
+      "name": "MONGODB_MEMORY_REQUEST",
+      "displayName": "Memory Request",
+      "description": "Minimum amount of memory the container can use.",
+      "value": "200Mi",
+      "required": true
+    },
+    {
+      "name": "MONGODB_MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "description": "Maximum amount of memory the container can use.",
+      "value": "1000Mi",
       "required": true
     }
   ]

--- a/mongo-standalone-ephemeral.json
+++ b/mongo-standalone-ephemeral.json
@@ -41,17 +41,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {
-            "limits": {
-              "cpu": "1000m",
-              "memory": "1000Mi"
-            },
-            "requests": {
-              "cpu": "200m",
-              "memory": "200Mi"
-            }
-          }
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -163,12 +153,12 @@
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "1000m",
-                    "memory": "1000Mi"
+                    "cpu": "${MONGODB_CPU_LIMIT}",
+                    "memory": "${MONGODB_MEMORY_LIMIT}"
                   },
                   "requests": {
-                    "cpu": "200m",
-                    "memory": "200Mi"
+                    "cpu": "${MONGODB_CPU_REQUEST}",
+                    "memory": "${MONGODB_MEMORY_REQUEST}"
                   }
                 },
                 "livenessProbe": {
@@ -228,6 +218,34 @@
       "name": "MONGO_INSTANCE",
       "description": "The Mongo service number",
       "value": "1"
+    },
+    {
+      "name": "MONGODB_CPU_REQUEST",
+      "displayName": "CPU Request",
+      "description": "Minimum amount of CPU the container can use.",
+      "value": "5m",
+      "required": true
+    },
+    {
+      "name": "MONGODB_CPU_LIMIT",
+      "displayName": "CPU Limit",
+      "description": "Maximum amount of CPU the container can use.",
+      "value": "1",
+      "required": true
+    },
+    {
+      "name": "MONGODB_MEMORY_REQUEST",
+      "displayName": "Memory Request",
+      "description": "Minimum amount of memory the container can use.",
+      "value": "200Mi",
+      "required": true
+    },
+    {
+      "name": "MONGODB_MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "description": "Maximum amount of memory the container can use.",
+      "value": "1000Mi",
+      "required": true
     }
   ]
 }

--- a/mongo-standalone.json
+++ b/mongo-standalone.json
@@ -58,17 +58,7 @@
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {
-            "limits": {
-              "cpu": "1000m",
-              "memory": "1000Mi"
-            },
-            "requests": {
-              "cpu": "200m",
-              "memory": "200Mi"
-            }
-          }
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -194,14 +184,14 @@
                 ],
                 "resources": {
                   "limits": {
-                    "cpu": "1000m",
-                    "memory": "1000Mi"
+                    "cpu": "${MONGODB_CPU_LIMIT}",
+                    "memory": "${MONGODB_MEMORY_LIMIT}"
                   },
                   "requests": {
-                    "cpu": "200m",
-                    "memory": "200Mi"
+                    "cpu": "${MONGODB_CPU_REQUEST}",
+                    "memory": "${MONGODB_MEMORY_REQUEST}"
                   }
-                },
+                },            
                 "livenessProbe": {
                   "failureThreshold": 2,
                   "initialDelaySeconds": 5,
@@ -259,6 +249,34 @@
       "name": "MONGO_INSTANCE",
       "description": "The Mongo service number",
       "value": "1"
+    },
+    {
+      "name": "MONGODB_CPU_REQUEST",
+      "displayName": "CPU Request",
+      "description": "Minimum amount of CPU the container can use.",
+      "value": "5m",
+      "required": true
+    },
+    {
+      "name": "MONGODB_CPU_LIMIT",
+      "displayName": "CPU Limit",
+      "description": "Maximum amount of CPU the container can use.",
+      "value": "1",
+      "required": true
+    },
+    {
+      "name": "MONGODB_MEMORY_REQUEST",
+      "displayName": "Memory Request",
+      "description": "Minimum amount of memory the container can use.",
+      "value": "200Mi",
+      "required": true
+    },
+    {
+      "name": "MONGODB_MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "description": "Maximum amount of memory the container can use.",
+      "value": "1000Mi",
+      "required": true
     }
   ]
 }


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21570


# What
Adds request and limit parameters with more reasonable values based on actual usage across several clusters.  This also removes the extraneous/unused resources section under strategy which was misleading people into add/updating resource values there in addition to the correct ones under the spec template containers.  I think the reason they weren't flagged as incorrect by OpenShift is the support for deployment strategy custom which could include user-defined properties of unknown name.


# Why
This will allow self-managed customers as well as the NOC for hosted customers to adjust the values of specific components based on their actual usage rather than forcing every install to hard-coded worst-case scenario values.



# How
Required parameters added to all versions of component templates with default values set so that they will be available going forward without any additional configuration for most installs.


# Verification Steps
These template versions are backwards compatible with any method of installation by referencing the folder containing them.


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 